### PR TITLE
cann: deprecate `cann8.0.rc3.alpha002` with `python3.9`, use `cann8.0.rc3.beta1` with `python3.10`

### DIFF
--- a/arg.json
+++ b/arg.json
@@ -7,7 +7,7 @@
     {
       "url": "quay.io",
       "owner": "ascend"
-    }, 
+    },
     {
       "url": "swr.cn-southwest-2.myhuaweicloud.com",
       "owner": "base_image"
@@ -106,26 +106,26 @@
       ]
     },
     {
-      "cann_version": "8.0.RC3.alpha002",
+      "cann_version": "8.0.RC3",
       "cann_chip": "910b",
       "os_name": "ubuntu",
       "os_version": "22.04",
-      "py_version": "3.9",
+      "py_version": "3.10",
       "tags": [
-        "8.0.rc3.alpha002-910b-ubuntu22.04-py3.9",
+        "8.0.rc3.beta1-910b-ubuntu22.04-py3.9",
         "latest",
-        "ubuntu-python3.9-cann8.0.rc3.alpha002"
+        "ubuntu-python3.9-cann8.0.rc3.beta1"
       ]
     },
     {
-      "cann_version": "8.0.RC3.alpha002",
+      "cann_version": "8.0.RC3",
       "cann_chip": "910b",
       "os_name": "openeuler",
       "os_version": "22.03",
-      "py_version": "3.9",
+      "py_version": "3.10",
       "tags": [
-        "8.0.rc3.alpha002-910b-openeuler22.03-py3.9",
-        "openeuler-python3.9-cann8.0.rc3.alpha002"
+        "8.0.rc3.beta1-910b-openeuler22.03-py3.10",
+        "openeuler-python3.10-cann8.0.rc3.beta1"
       ]
     }
   ],

--- a/arg.json
+++ b/arg.json
@@ -112,9 +112,9 @@
       "os_version": "22.04",
       "py_version": "3.10",
       "tags": [
-        "8.0.rc3.beta1-910b-ubuntu22.04-py3.9",
+        "8.0.rc3.beta1-910b-ubuntu22.04-py3.10",
         "latest",
-        "ubuntu-python3.9-cann8.0.rc3.beta1"
+        "ubuntu-python3.10-cann8.0.rc3.beta1"
       ]
     },
     {

--- a/cann/cann.sh
+++ b/cann/cann.sh
@@ -29,6 +29,7 @@ download_file() {
     local retry_delay=10
     local url="$1"
     local path="$2"
+    echo "Downloading ${path} from ${url}"
 
     for ((i=1; i<=max_retries; i++)); do
         echo "Attempt $i of $max_retries..."
@@ -63,12 +64,10 @@ download_cann() {
     local kernels_url="${url_prefix}/${KERNELS_FILE}?${url_suffix}"
 
     if [ ! -f "${TOOLKIT_PATH}" ]; then
-        echo "Downloading ${TOOLKIT_FILE} from ${toolkit_url}"
         download_file "${toolkit_url}" "${TOOLKIT_PATH}"
     fi
 
     if [ ! -f "${KERNELS_PATH}" ]; then
-        echo "Downloading ${KERNELS_FILE} from ${kernels_url}"
         download_file "${kernels_url}" "${KERNELS_PATH}"
     fi
 

--- a/cann/cann.sh
+++ b/cann/cann.sh
@@ -42,20 +42,21 @@ download_file() {
     done
 
     echo "All attempts failed. Exiting."
-    return 1
+    exit 1
 }
 
 download_cann() {
+    local url="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com"
     if [[ ${CANN_VERSION} == "8.0.RC2.alpha001" ]]; then
-        local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C18B800TP015"
+        local url_prefix="${url}/Milan-ASL/Milan-ASL%20V100R001C18B800TP015"
     elif [[ ${CANN_VERSION} == "8.0.RC2.alpha002" ]]; then
-        local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C18SPC805"
+        local url_prefix="${url}/Milan-ASL/Milan-ASL%20V100R001C18SPC805"
     elif [[ ${CANN_VERSION} == "8.0.RC2.alpha003" ]]; then
-        local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C18SPC703"
+        local url_prefix="${url}/Milan-ASL/Milan-ASL%20V100R001C18SPC703"
     elif [[ ${CANN_VERSION} == "8.0.RC3.alpha002" ]]; then
-        local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C19SPC702"
+        local url_prefix="${url}/Milan-ASL/Milan-ASL%20V100R001C19SPC702"
     else
-        local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%20${CANN_VERSION}"
+        local url_prefix="${url}/CANN/CANN%20${CANN_VERSION}"
     fi
     local url_suffix="response-content-type=application/octet-stream"
     local toolkit_url="${url_prefix}/${TOOLKIT_FILE}?${url_suffix}"
@@ -92,7 +93,7 @@ set_env() {
 install_cann() {
     # Download installers
     if [ ! -f "${TOOLKIT_PATH}" ] || [ ! -f "${KERNELS_PATH}" ]; then
-        echo "[WARNING] Installers do not exist, re-download them."
+        echo "[WARNING] Installers do not exist in the /tmp directory, re-download them."
         download_cann
     fi
 
@@ -125,8 +126,15 @@ CANN_HOME=${CANN_HOME:="/usr/local/Ascend"}
 CANN_CHIP=${CANN_CHIP:="910b"}
 CANN_VERSION=${CANN_VERSION:="8.0.RC1"}
 
+# NOTE: kernels are arch-specific after 8.0.RC3.alpha002
+if [[ ${CANN_VERSION} == "8.0.RC3" ]]; then
+  KERNELS_ARCH="linux-${ARCH}"
+else
+  KERNELS_ARCH="linux"
+fi
+
 TOOLKIT_FILE="Ascend-cann-toolkit_${CANN_VERSION}_linux-${ARCH}.run"
-KERNELS_FILE="Ascend-cann-kernels-${CANN_CHIP}_${CANN_VERSION}_linux.run"
+KERNELS_FILE="Ascend-cann-kernels-${CANN_CHIP}_${CANN_VERSION}_${KERNELS_ARCH}.run"
 TOOLKIT_PATH="/tmp/${TOOLKIT_FILE}"
 KERNELS_PATH="/tmp/${KERNELS_FILE}"
 


### PR DESCRIPTION
NOTE: kernels are arch-specific after 8.0.RC3.alpha002
